### PR TITLE
Surface Pen Support

### DIFF
--- a/orientation-helper
+++ b/orientation-helper
@@ -60,7 +60,7 @@ do
   props=$(xinput list-props $id)
 
   # Filter for touch devices
-  IS_TOUCH=$(echo $props | grep -i '\(Touchscreen\|ELAN\|wacom\)')
+  IS_TOUCH=$(echo $props | grep -i 'Touchscreen\|ELAN\|Pen\|Eraser\|wacom')
 
   # Apply Input Matrix for touch devices
   if [ -n "$IS_TOUCH" ];
@@ -74,7 +74,7 @@ do
         xinput set-prop $id "$WACOM_PROP" $WACOM 2>/dev/null
       elif [ -n "$HAS_GENERIC" ]
       then
-        xinput set-prop $id "$GENERIC_PROP" $GENERIC 2>/dev/null
+        xinput set-prop $id "$GENERIC_PROP" $GENERIC>/dev/null
       fi
     fi
 done

--- a/orientation-helper
+++ b/orientation-helper
@@ -74,7 +74,7 @@ do
         xinput set-prop $id "$WACOM_PROP" $WACOM 2>/dev/null
       elif [ -n "$HAS_GENERIC" ]
       then
-        xinput set-prop $id "$GENERIC_PROP" $GENERIC>/dev/null
+        xinput set-prop $id "$GENERIC_PROP" $GENERIC 2>/dev/null
       fi
     fi
 done


### PR DESCRIPTION
Another pull request because the other one was broken.
- Added the devices "Pen" and "Eraser" to change the transformation matrix for those
- Removed wrong brackets so that all touch-devices can be found
- Reverted the 2 as stderr redirection