### PR TITLE
eGalaxTouch Support and CMakeLists Enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,6 @@ install(TARGETS kded_rotation
         DESTINATION ${PLUGIN_INSTALL_DIR}
 )
 
-install(FILES orientation-helper
+install(PROGRAMS orientation-helper
 	DESTINATION ${BIN_INSTALL_DIR}
 )

--- a/orientation-helper
+++ b/orientation-helper
@@ -60,7 +60,7 @@ do
   props=$(xinput list-props $id)
 
   # Filter for touch devices
-  IS_TOUCH=$(echo $props | grep -i 'Touchscreen\|ELAN\|Pen\|Eraser\|wacom\|maXTouch')
+  IS_TOUCH=$(echo $props | grep -i 'Touchscreen\|ELAN\|Pen\|Eraser\|wacom\|maXTouch\|eGalaxTouch')
 
   # Apply Input Matrix for touch devices
   if [ -n "$IS_TOUCH" ];


### PR DESCRIPTION
This pull request adds eGalaxTouch touch screen matching, which is found on Panasonic CF-RZ series laptops/convertibles (tested on my CF-RZ4). Another change made is marking `orientation-helper` as an executable, this eliminates the need for a manual `chmod` at the end.