### PR TITLE
Generalize README.md for Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kded_rotation
 
-KDED module for handling automatic screen rotation on X11, with visual feedback before orientation change happens. Some assembly might be required.
+KDED module for handling automatic screen rotation, with visual feedback before orientation change happens. Some assembly might be required.
 
 # Installation
 
@@ -10,7 +10,7 @@ You'll most likely need `qt5-qtbase-devel`, `cmake-utils`, `extra-cmake-modules`
 
 # Usage
 
-`orientation-helper` is where the actual screen rotation happens. This is achieved by calling `xrandr --rotation $value`, which works in most circumstances. You can adjust `orientation-helper` to fit your setup and reinstall to apply.
+`orientation-helper` is where the actual screen rotation happens. You can edit it to fit your setup and reinstall to apply.
 
 To reduce or increase the timer before the rotation happens, adjust `timer.start(25);` in `screenrotator.cpp`:
 


### PR DESCRIPTION
This was requested by https://github.com/dos1/kded_rotation/pull/33#issuecomment-1362678535 . It is independent of #33, and can be applied before, after, or not at all. This is a separate PR because I predict a `README.md` change is more at risk of bikeshedding.

I generalized the wording to refer to neither X11 nor Wayland. Perhaps it's too early to say whether there will be another display server kwin would be ported to, but the new wording is shorter and simpler. With this, we won't have to change the wording again once that day comes.